### PR TITLE
Fix typo of example

### DIFF
--- a/doc/docs/advanced/global-theme-value.mdx
+++ b/doc/docs/advanced/global-theme-value.mdx
@@ -58,7 +58,7 @@ export const StyledSystemAppThemeProvider = ({ children }: PropsWithChildren<{}>
 
 //highlight-start
   useEffect(() => {
-    globalTheme = theme;
+    _globalTheme = theme;
   }, [theme]);
 //highlight-end
 


### PR DESCRIPTION
* 코드 예제의 useEffect 내부에서 사용하는 전역 변수에 _가 빠진 것 같습니다
   * [링크](https://mj-studio-library.github.io/react-native-styled-system/docs/advanced/global-theme-value/)