### PR TITLE
Resolve #39 Default style property in `useSx` option

### DIFF
--- a/doc/docs/advanced/get-token-value.mdx
+++ b/doc/docs/advanced/get-token-value.mdx
@@ -18,7 +18,7 @@ const MyView = (
     readonly?: boolean;
   }) => {
   const [backgroundColor, error] = useSxTokens('colors', [readonly || disabled ? 'gray500' : 'gray200', 'red500']);
-g
+
   return <View style={{ backgroundColor, borderColor: error, ... }} />
 }
 ```

--- a/doc/docs/usage/component.mdx
+++ b/doc/docs/usage/component.mdx
@@ -97,16 +97,17 @@ type Props = {
   title?: string;
   body?: string;
 //highlight-next-line
-} &SxProps;
+} & SxProps;
 const ScreenErrorFallback = (props: Props) => {
 //highlight-next-line
   const { title, body } = props;
 //highlight-next-line
   const { getStyle } = useSx(props);
+  const getSxStyle = useSxStyle();
   return (
     <View
 //highlight-next-line
-      style={getStyle({ center: true })}
+      style={[getStyle(), getSxStyle({ center: true })]}
       pointerEvents={'box-none'}
     >
 ```
@@ -117,7 +118,7 @@ There are a few things to keep in mind.
 There is no need to add `style` as a prop to `style` of `View`.
 2. Always pass all `props` objects themselves to `useSx` to avoid missing any properties. `useSx`
 Properties that are not used internally are ignored and not changed.
-3. `getStyle` can receive `SxProps` as an argument and consider it in the result.
+3. Fixed style overwriting `props` can be applied with `getSxStyle`.
 4. `center` is a shortcut for `justifyContent: center`, `alignItems: center`.
 
 ## Example without Props destruction

--- a/doc/docs/usage/style-parsing.mdx
+++ b/doc/docs/usage/style-parsing.mdx
@@ -52,5 +52,5 @@ This is because when integrating this package, we want to maximize stability whe
 
 :::tip
 If you are not sure what to write and are confused,
-we recommend removing all of the code that was #3 in the beginning and introducing only #5 and #2 first.
+we recommend removing all of the code that was #3 in the begining and introducing only #5 and #2 first.
 :::

--- a/doc/docs/usage/style-parsing.mdx
+++ b/doc/docs/usage/style-parsing.mdx
@@ -11,49 +11,44 @@ Let me show the following snippet.
 
 ```tsx
 const props = {
-  style: { marginTop: 24 }, // #3
-  sx: { mt: '24px' }, // #4
-  mt: '24px', // #5
+  style: { marginTop: 24 }, // #2
+  sx: { mt: '24px' }, // #3
+  mt: '24px', // #4
 }
 
 const { getStyle, filteredProps } = useSx(props, {
-  transform: ({ /* ... */ }) => ({ mt: 4 }), // #2
-  fallback: { mt: 8 }, // #6
+  transform: ({ /* ... */ }) => ({ mt: 4 }), // #1
+  fallback: { mt: 8 }, // #5
 });
 
-return <View style={getStyle({ mt: 2 } /* #1 */ )} />
+return <View style={getStyle()} />
 ```
 
-1. Argument `sx` of `getStyle(sx?: TextSxProps)`
-2. Parsed result of `transform` in the `useSx` options
-3. Plain old `style` prop
-4. `sx` in props
-5. Plain properties in props, such as `ml` or `color`
-6. `fallback` in the `useSx` options (To be added)
+1. Parsed result of `transform` in the `useSx` options
+2. Plain old `style` prop
+3. `sx` in props
+4. Plain properties in props, such as `ml` or `color`
+5. `fallback` in the `useSx` options (To be added)
 
-**The priority is calculated as  1 > 2 > 3 > 4 > 5 > 6.**
+**The priority is calculated as  1 > 2 > 3 > 4 > 5.**
 
 > 1 has the highest priority.
 
 The reasons for this priority are as follows:
 
-**First of all, #6 should always have the lowest priority.**
+**First of all, #5 should always have the lowest priority.**
 
 As the name suggests, it means `fallback`.
 
-**And #2 should have at least a higher priority than #3-5.**
+**And #1 should have at least a higher priority than #2-4.**
 
-In the aspect of user of this component, they can only set #3-5.
+In the aspect of user of this component, they can only set #2-4.
 
 The reason `transform` is created is to calculate the value of another property based on the result of these or to change the value of the passed property. .
 
-**#3 should have higher priority than #4 and #5.**
+**#2 should have higher priority than #3 and #4.**
 
 This is because when integrating this package, we want to maximize stability when refactoring existing code.
-
-:::warning To Be Discussed
-**We should decide that #1 is really needed in this package later**
-:::
 
 :::tip
 If you are not sure what to write and are confused,

--- a/example/src/components/Txt.tsx
+++ b/example/src/components/Txt.tsx
@@ -7,9 +7,12 @@ import { useSx } from 'react-native-themed-styled-system';
 type TxtProps = {} & TextSxProps & TextProps;
 
 const Txt = (props: TxtProps) => {
-  const { getStyle, filteredProps } = useSx(props, { styleType: 'TextStyle' });
+  const { getStyle, filteredProps } = useSx(props, {
+    styleType: 'TextStyle',
+    fallback: { color: 'text', includeFontPadding: false },
+  });
 
-  return <Text style={getStyle({ color: 'text', includeFontPadding: false })} {...filteredProps} />;
+  return <Text style={getStyle()} {...filteredProps} />;
 };
 
 export { Txt };

--- a/src/hook/useSx.test.ts
+++ b/src/hook/useSx.test.ts
@@ -338,4 +338,11 @@ describe('transform', () => {
       },
     );
   });
+
+  it('transform output should be honored even all props are null', () => {
+    expectResult(baseTheme, undefined as any, {
+      expectation: { marginHorizontal: 4 },
+      transform: () => ({ mx: 1 }),
+    });
+  });
 });

--- a/src/hook/useSx.test.ts
+++ b/src/hook/useSx.test.ts
@@ -3,38 +3,39 @@ import { StyleSheet } from 'react-native';
 import { is } from '@mj-studio/js-util';
 import { renderHook } from '@testing-library/react-hooks';
 
-import type { SxProps, TextSxProps } from '../@types/SxProps';
+import type { TextSxProps } from '../@types/SxProps';
 import type { ThemedDict } from '../@types/ThemedDict';
 import { emptyThemedDict } from '../@types/ThemedDict';
 import type { ThemedStyleType } from '../util/propsToThemedStyle';
 
-import type { StyleTransform } from './useSx';
+import type { StyleFallback, StyleTransform } from './useSx';
 import { useSx } from './useSx';
 
 export function expectResult(
   theme: ThemedDict,
-  props: { style?: StyleProp<any>; getStyleSx?: SxProps & TextSxProps } & TextSxProps &
-    Record<string, any>,
+  props: { style?: StyleProp<any> } & TextSxProps & Record<string, any>,
   {
     expectation,
     filteredPropsExpectation,
     styleType,
     transform,
+    fallback,
   }: {
     expectation: object;
     filteredPropsExpectation?: object;
     styleType?: ThemedStyleType;
     transform?: StyleTransform;
+    fallback?: StyleFallback;
   },
 ) {
   const {
     result: {
       current: { getStyle, filteredProps },
     },
-  } = renderHook(() => useSx(props, { theme, styleType, transform }));
+  } = renderHook(() => useSx(props, { theme, styleType, transform, fallback }));
 
   if (expectation) {
-    expect(StyleSheet.flatten(getStyle(props.getStyleSx))).toEqual(expectation);
+    expect(StyleSheet.flatten(getStyle())).toEqual(expectation);
   }
 
   if (filteredPropsExpectation) {
@@ -116,14 +117,14 @@ describe('edge case', () => {
     return expect(getStyle()).toEqual(undefined);
   });
 
-  it('if prop is nullish and getStyle sx parameter is not nullish, return style', () => {
+  it('if prop is nullish and fallback parameter is not nullish, return fallback style', () => {
     const {
       result: {
         current: { getStyle },
       },
-    } = renderHook(() => useSx(null, { theme: baseTheme }));
+    } = renderHook(() => useSx(null, { theme: baseTheme, fallback: { w: 1 } }));
 
-    return expect(getStyle({ width: 1 })).toEqual({ width: 4 });
+    return expect(getStyle()).toEqual({ width: 4 });
   });
 
   it("gap doesn't accept not number value", () => {
@@ -209,20 +210,25 @@ describe('shortcut priority', () => {
 });
 
 describe('style parse priority', () => {
+  it('prop property > fallback property', () => {
+    expectResult(
+      emptyTheme,
+      { w: 1 },
+      {
+        fallback: {
+          w: 2,
+        },
+        expectation: { width: 1 },
+      },
+    );
+  });
+
   it('sx prop property > prop property', () => {
     expectResult(emptyTheme, { w: 1, sx: { w: 2 } }, { expectation: { width: 2 } });
   });
 
-  it('prop property > getStyle parameter', () => {
-    expectResult(emptyTheme, { w: 1, getStyleSx: { w: 2 } }, { expectation: { width: 1 } });
-  });
-
-  it('style prop property > getStyle parameter', () => {
-    expectResult(
-      emptyTheme,
-      { style: { width: 1 }, getStyleSx: { w: 2 } },
-      { expectation: { width: 1 } },
-    );
+  it('style prop property > sx prop property', () => {
+    expectResult(emptyTheme, { style: { width: 1 }, sx: { w: 2 } }, { expectation: { width: 1 } });
   });
 });
 

--- a/src/hook/useSx.ts
+++ b/src/hook/useSx.ts
@@ -36,12 +36,15 @@ export const useSx = <S extends ViewStyle = ViewStyle, P extends Props = Props>(
 
   const getStyle = useStableCallback((): StyleProp<S> | undefined => {
     const skip = !props && !fallback;
+    const theme = optionTheme ?? styledSystemContext?.theme;
 
     if (skip) {
-      return;
+      if (is.function(transform)) {
+        return propsToThemedStyle({ theme, sx: transform({}) }) as S;
+      } else {
+        return;
+      }
     }
-
-    const theme = optionTheme ?? styledSystemContext?.theme;
 
     if (!theme) {
       printWarning('theme not found from useSx, undefined will be returned.');


### PR DESCRIPTION
<!-- Thank you for contributing `react-native-themed-styled-system` package :hugging_face: -->

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## What does this change?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
<!-- Please delete section if it is not a PR changes feature. -->

* add `fallback` style option to `useSx` 
* remove `getStyle-sx` props

Resolve #39 :dart: